### PR TITLE
Implementation for cancelling trips that were previously added

### DIFF
--- a/.idea/Protobuf Parser.iml
+++ b/.idea/Protobuf Parser.iml
@@ -9,4 +9,7 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
+  <component name="SonarLintModuleSettings">
+    <option name="uniqueId" value="d85170e6-3d7f-4bc5-8e15-a51a41336107" />
+  </component>
 </module>

--- a/src/Models/GTFS/StopTimeUpdate.ts
+++ b/src/Models/GTFS/StopTimeUpdate.ts
@@ -36,7 +36,7 @@ export class  StopTimeUpdate implements IStopTimeUpdate {
         const departureIsZero = departureTime.isZero();
         // If the departure is before the arrival, this must be an error, so we add 1 minute to the arrival time and make it the new departure time.
         if(departureBeforeArrival) {
-            console.log(`[StopTimeUpdate] Departure before arrival (NEGATIVE_DWELL_TIME). Adding 1 minute to the arrival time and setting it as the departure time.`)
+            // console.log(`[StopTimeUpdate] Departure before arrival (NEGATIVE_DWELL_TIME). Adding 1 minute to the arrival time and setting it as the departure time.`)
             departureTime = arrivalTime.add(60)
         }
             
@@ -62,7 +62,7 @@ export class  StopTimeUpdate implements IStopTimeUpdate {
             transit_realtime.TripUpdate.StopTimeUpdate.ScheduleRelationship.SKIPPED :
             transit_realtime.TripUpdate.StopTimeUpdate.ScheduleRelationship.SCHEDULED;
 
-        const shouldHaveDepartureAndArrival = true; //!update.isCancelled();
+        const shouldHaveDepartureAndArrival = true;
 
         return new StopTimeUpdate({
             stopId,

--- a/src/Models/General/Collection.ts
+++ b/src/Models/General/Collection.ts
@@ -58,4 +58,12 @@ export class Collection<T> {
     public every(callbackfn: (value: T, index: number, array: T[]) => unknown, thisArg?: any): boolean {
         return this._items.every(callbackfn, thisArg);
     }
+
+    /**
+     * Appends new elements to the end of an array, and returns the new length of the array.
+     * @param items New elements to add to the array.
+     */
+    public push(...items: T[]): number {
+        return this._items.push(...items);
+    }
 }


### PR DESCRIPTION
Sometimes trips get added with custom trip IDs but are later on cancelled, deleted or simply not needed anymore. When a trip was added but then got removed later on, it will now automatically be marked as cancelled