### PR TITLE
Fix: scheduled trains in 100k-900k number range incorrectly marked as ADDED

### DIFF
--- a/src/Models/RitInfoUpdate.ts
+++ b/src/Models/RitInfoUpdate.ts
@@ -302,7 +302,10 @@ export class RitInfoUpdate {
         //Could be incorrect, maybe only 300.000 and 700.000 are added.
         if (!isAdded) {
             // If the short train number does not match the train number, it is an extra train. (E.g. 301234 vs 1234, 701234 vs 1234 or 201234 vs 1234)
-            isAdded = this._shortTrainNumber !== this._trainNumber || (this._trainNumber > 100_000 && this._trainNumber < 900_000);
+            // However, if a static tripId was found, the trip is in the scheduled timetable and should NOT be marked as added,
+            // even if its number falls in the 100k–900k range (e.g. train 703535 which is a regular scheduled IC).
+            const hasStaticTrip = this._tripId !== null;
+            isAdded = (this._shortTrainNumber !== this._trainNumber || (this._trainNumber > 100_000 && this._trainNumber < 900_000)) && !hasStaticTrip;
         }
 
         return isAdded;


### PR DESCRIPTION
## Problem

Trains with numbers in the 100,000–900,000 range (e.g. IC **703535**) were being marked as `isAdded = true` due to an overly broad numeric heuristic in `RitInfoUpdate.isAdded`, even when the train exists in the scheduled GTFS timetable.

**Root cause** — `src/Models/RitInfoUpdate.ts`:
```typescript
// Before
isAdded = this._shortTrainNumber !== this._trainNumber
       || (this._trainNumber > 100_000 && this._trainNumber < 900_000);
```

For train 703535: `shortTrainNumber === trainNumber` (no mismatch), but `703535 > 100_000` triggered `isAdded = true`. This caused `TrainUpdate` to append `_added` to the tripId and emit `scheduleRelationship: ADDED`, creating a phantom trip instead of updating the real one.

**Effect in the route planner:** The scheduled trip `248441183` was never invalidated (no GTFS-RT update for it), while a new ghost trip `248441183_added` was emitted — causing duplicate/stale results.

## Fix

Only apply the number-range heuristic when **no static tripId was found** in the database. If the DB join resolved a `tripId`, the train is provably in the scheduled timetable.

```typescript
// After
const hasStaticTrip = this._tripId !== null;
isAdded = (this._shortTrainNumber !== this._trainNumber
       || (this._trainNumber > 100_000 && this._trainNumber < 900_000))
       && !hasStaticTrip;
```

Genuinely extra trains in the 700k series that have no static trip are still correctly marked as ADDED via the `customTripId` fallback path in `TrainUpdate`.

## Verified locally

Cloned production DB and ran the service locally against it:

| | Before | After |
|---|---|---|
| `id` | `248441183_added` | `248441183` |
| `scheduleRelationship` | `ADDED` | `REPLACEMENT` |

The trip is now emitted as `REPLACEMENT` (correct — it has a real-time stop change at RTD), updating the existing scheduled trip rather than creating a duplicate.