### PR TITLE
fix: treat actualWillStop=false stops as cancelled/skipped

### DIFF
--- a/src/Models/StopUpdates/RitinfoStopUpdate.ts
+++ b/src/Models/StopUpdates/RitinfoStopUpdate.ts
@@ -42,6 +42,8 @@ export class RitInfoStopUpdate extends StopUpdate {
         this.platform = update.platform;
         this.track = update.track;
 
+        this.plannedWillStop = update.plannedWillStop;
+        this.actualWillStop = update.actualWillStop;
 
         this.name = update.name;
 
@@ -100,6 +102,11 @@ export class RitInfoStopUpdate extends StopUpdate {
      * @returns {boolean} True if the stop has been cancelled, false otherwise.
      */
     public isCancelled(): boolean {
+        // If the train will not actually stop here, treat as skipped regardless of changes.
+        // This handles international border stops (e.g. BHF for ICE) where plannedWillStop=true
+        // but actualWillStop=false, causing out-of-order times that cannot be fixed.
+        if (this.actualWillStop === false) return true;
+
         if (!this.changes) return false;
 
         //If the passing has been cancelled, the whole stop has been cancelled.


### PR DESCRIPTION
## Problem

`RitInfoStopUpdate` had two bugs:

1. `plannedWillStop` and `actualWillStop` were **never assigned** in the constructor, leaving them always `undefined`.
2. `isCancelled()` did not account for `actualWillStop === false`, causing international border stops (e.g. `BHF` on ICE 146) to pass through with backward/out-of-order times instead of being emitted as `SKIPPED`.

### Root cause

For inbound ICE 146, the stop `BHF` had `plannedWillStop=true, actualWillStop=false, changeType=32` only. The SQL filter (`plannedWillStop=true OR actualWillStop=true`) correctly included it, but the old `isCancelled()` required explicit `CancelledArrival`+`CancelledDeparture` change types — which were absent. So `BHF` was emitted with a backward departure time, producing unresolvable non-increasing hop time warnings.

## Fix

- Assign `plannedWillStop` and `actualWillStop` in the constructor.
- Short-circuit `isCancelled()` when `actualWillStop === false` — any stop the train will not actually serve is treated as cancelled/skipped regardless of which change types are present.

## Effect

Stops where `actualWillStop=false` are now emitted as `SKIPPED` `stop_time_update`s, eliminating the non-increasing hop time warnings for international trains (ICE, ECD) and any domestic trains with such stops.